### PR TITLE
supply FastInvoker interface for reduce the function call memory cons…

### DIFF
--- a/inject.go
+++ b/inject.go
@@ -50,18 +50,32 @@ type Invoker interface {
 	Invoke(interface{}) ([]reflect.Value, error)
 }
 
-// FastInvoker represents an interface for fast calling functions external function.
+// FastInvoker represents an interface in order to avoid the calling function via reflection.
+//
+// example:
+//	type handlerFuncHandler func(http.ResponseWriter, *http.Request) error
+//	func (f handlerFuncHandler)Invoke([]interface{}) ([]reflect.Value, error){
+//		ret := f(p[0].(http.ResponseWriter), p[1].(*http.Request))
+//		return []reflect.Value{reflect.ValueOf(ret)}, nil
+//	}
+//
+//	type funcHandler func(int, string)
+//	func (f funcHandler)Invoke([]interface{}) ([]reflect.Value, error){
+//		f(p[0].(int), p[1].(string))
+//		return nil, nil
+//	}
 type FastInvoker interface {
-	// Invoke
+	// Invoke attempts to call the ordinary functions. If f is a function
+	// with the appropriate signature, f.Invoke([]interface{}) is a Call that calls f.
+	// Returns a slice of reflect.Value representing the returned values of the function.
+	// Returns an error if the injection fails.
 	Invoke([]interface{}) ([]reflect.Value, error)
 }
 
 // IsFastInvoker check interface is FastInvoker
 func IsFastInvoker(h interface{}) bool {
-	if _, ok := h.(FastInvoker); ok {
-		return true
-	}
-	return false
+	_, ok := h.(FastInvoker)
+	return ok
 }
 
 // TypeMapper represents an interface for mapping interface{} values based on type.

--- a/inject_test.go
+++ b/inject_test.go
@@ -182,7 +182,7 @@ func Test_Injector_Implementors(t *testing.T) {
 	})
 }
 
-//----------Benchmark Injecto rInvoke-------------
+//----------Benchmark InjectorInvoke-------------
 
 func f1InjectorInvoke(d1 string, d2 SpecialString) string {
 	return "f1"

--- a/inject_test.go
+++ b/inject_test.go
@@ -181,3 +181,88 @@ func Test_Injector_Implementors(t *testing.T) {
 		So(injector.GetVal(inject.InterfaceOf((*fmt.Stringer)(nil))).IsValid(), ShouldBeTrue)
 	})
 }
+
+//----------Benchmark Injecto rInvoke-------------
+
+func f1InjectorInvoke(d1 string, d2 SpecialString) string {
+	return "f1"
+}
+func f2InjectorInvoke(d1 string, d2 SpecialString) string {
+	return "f2"
+}
+
+func f1SimpleInjectorInvoke() {
+}
+func f2SimpleInjectorInvoke() {
+}
+
+// f2InjectorInvokeHandler f2 Invoke Handler
+type f2InjectorInvokeHandler func(d1 string, d2 SpecialString) string
+
+func (f2 f2InjectorInvokeHandler) Invoke(p []interface{}) ([]reflect.Value, error) {
+	ret := f2(p[0].(string), p[1].(SpecialString))
+	return []reflect.Value{reflect.ValueOf(ret)}, nil
+}
+
+type f2SimpleInjectorInvokeHandler func()
+
+func (f2 f2SimpleInjectorInvokeHandler) Invoke(p []interface{}) ([]reflect.Value, error) {
+	f2()
+	return nil, nil
+}
+
+func BenchmarkInjectorInvokeNative(b *testing.B) {
+	b.StopTimer()
+	dep := "some dependency"
+	dep2 := "another dep"
+	var d2 SpecialString
+	d2 = dep2
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		f1InjectorInvoke(dep, d2)
+	}
+}
+
+func BenchmarkInjectorInvokeOriginal(b *testing.B) {
+	benchmarkInjectorInvoke(b, false, false)
+}
+func BenchmarkInjectorInvokeFast(b *testing.B) {
+	benchmarkInjectorInvoke(b, true, false)
+}
+func BenchmarkInjectorInvokeOriginalSimple(b *testing.B) {
+	benchmarkInjectorInvoke(b, false, true)
+}
+func BenchmarkInjectorInvokeFastSimple(b *testing.B) {
+	benchmarkInjectorInvoke(b, true, true)
+}
+func benchmarkInjectorInvoke(b *testing.B, isFast, isSimple bool) {
+	b.StopTimer()
+
+	injector := inject.New()
+	dep := "some dependency"
+	injector.Map(dep)
+	dep2 := "another dep"
+	injector.MapTo(dep2, (*SpecialString)(nil))
+
+	var f1 interface{}
+	var f2 interface{}
+	if isSimple { //func()
+		f1 = f1SimpleInjectorInvoke
+		f2 = f2SimpleInjectorInvokeHandler(f2SimpleInjectorInvoke)
+	} else { //func(p1, p2) ret
+		f1 = f1InjectorInvoke
+		f2 = f2InjectorInvokeHandler(f2InjectorInvoke)
+	}
+	injector.Invoke(f1)
+	injector.Invoke(f2)
+
+	b.StartTimer()
+	for i := 0; i < b.N; i++ {
+		if isFast {
+			injector.Invoke(f2)
+		} else {
+			injector.Invoke(f1)
+		}
+	}
+}


### PR DESCRIPTION
`inject.Invoke()` 实现中 `reflect.ValueOf(f).Call(in)` 调用会消耗大量内存, 在 `长连接` 的请求中会导致大量内存占用, 影响服务器性能. 现在提供一个 `显式` 的 `FastInvoke` 接口, 对于特定的 `Handler` 提供一个直接 `显式调用函数` 的实现, 来减少内存消耗, `Invoke()` 执行速度上也有大概 `1/3` 的提升. 
本次 `PR` 对 `inject/macaron/sockets` 几个项目都做了修改和整合. 
