### PR TITLE
inject: add Clear method to clear values in the injector.

### DIFF
--- a/inject.go
+++ b/inject.go
@@ -31,6 +31,8 @@ type Injector interface {
 	// dependency in its Type map it will check its parent before returning an
 	// error.
 	SetParent(Injector)
+	// Clear clears the values in the injector.
+	Clear()
 }
 
 // Applicator represents an interface for mapping dependencies to a struct.
@@ -121,6 +123,14 @@ func New() Injector {
 	return &injector{
 		values: make(map[reflect.Type]reflect.Value),
 	}
+}
+
+// Clear clears the values in the injector.
+func (inj *injector) Clear() {
+	for k := range inj.values {
+		delete(inj.values, k)
+	}
+	inj.parent = nil
 }
 
 // Invoke attempts to call the interface{} provided as a function,

--- a/inject_test.go
+++ b/inject_test.go
@@ -162,6 +162,31 @@ func Test_Injector_GetVal(t *testing.T) {
 	})
 }
 
+func Test_Injector_Clear(t *testing.T) {
+	Convey("Clear", t, func() {
+		injector := inject.New()
+		So(injector, ShouldNotBeNil)
+
+		injector.Map("some dependency")
+
+		So(injector.GetVal(reflect.TypeOf("string")).IsValid(), ShouldBeTrue)
+		injector.Clear()
+		So(injector.GetVal(reflect.TypeOf("string")).IsValid(), ShouldBeFalse)
+
+		Convey("with parent", func() {
+			injector2 := inject.New()
+			So(injector, ShouldNotBeNil)
+			injector.MapTo("another dep", (*SpecialString)(nil))
+
+			injector2.SetParent(injector)
+
+			So(injector2.GetVal(inject.InterfaceOf((*SpecialString)(nil))).IsValid(), ShouldBeTrue)
+			injector.Clear()
+			So(injector2.GetVal(inject.InterfaceOf((*SpecialString)(nil))).IsValid(), ShouldBeFalse)
+		})
+	})
+}
+
 func Test_Injector_SetParent(t *testing.T) {
 	Convey("Set parent of injector", t, func() {
 		injector := inject.New()


### PR DESCRIPTION
This clears the values and resets the parent of an injector. This allows
reuse of injector without allocating a new one.

---

This is a method which I need to reduce allocs/op in [go-macaron/macaron](https://github.com/go-macaron/macaron) using `sync.Pool` for Context, an issue I am working on currently.